### PR TITLE
Adding highlight code and katex to initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,33 +73,36 @@ You can also write you quiz in an external markdown file and reference it like s
 
 The HTML builder will wrap a `<div class="quizdown"></div>` around the text and includes the `quizdown.js` library in the build.
 
-To use another version of quizdown or to set global options you can place a dictionary `quizdown_config` in your project's `conf.py` and change some of the values (quizdown uses the default option of not specified):
+To use another version of quizdown or to set global options you can place a dictionary `quizdown_config` in your project's `conf.py` and change some of the values (quizdown uses the default option if not specified):
 
 ```python
 # global options passed to the quizdown library
 quizdown_config = {
-    'quizdown_js': 'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js' # quizdown javascript
+    'quizdown_js': 'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js', # quizdown javascript
     'start_on_load': True,			# detect and convert all divs with class quizdown
     'shuffle_answers': True,		# shuffle answers for each question
     'shuffle_questions': False,     # shuffle questsions for each quiz
     'primary_color': '#FF851B',     # primary CSS color
     'secondary_color': '#DDDDDD',   # secondary CSS color
-    'text_color': 'black',          # text color of interactive elements
-    'locale': 'en'                  # language of text in user interface
+    'title_color': 'green',         # text color of the title
+    'highlight_code': False,        # Enable or disable code highlighting
+    'quizdown_highlight_js' : 'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@0.6.0/public/build/extensions/quizdownHighlight.js' # Code highlight js
+    'katex_math' : False,           # Enable or disable katex math parser
+    'katex_math_js': 'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@0.6.0/public/build/extensions/quizdownKatex.js' # Katex js
 }
 ```
 
-
 ## 📚 Documentation
 
-> The quizzes are for fun and not for serious assessment. Since everything is rendered on the client side, the hints and solutions to the questions become visible once javascript is disabled in the browser.
+> The quizzes are for fun and not for serious assessment.
+Since everything is rendered on the client side, the hints and solutions to the questions become visible once javascript is disabled in the browser.
 
-Check out the [documentation](https://github.com/bonartm/quizdown-js/blob/main/docs/) on the main project page. You might be interested in:
+Check out the [documentation](https://github.com/bonartm/quizdown-js/blob/main/docs/) on the main project page.
+You might be interested in:
 
 - different [quiz-types](https://github.com/bonartm/quizdown-js/blob/main/docs/syntax.md): single-choice, multiple-choice, sequence.
 - support for [hints and explanations](https://github.com/bonartm/quizdown-js/blob/main/docs/syntax.md#hints-and-comments).
 - [options](https://github.com/bonartm/quizdown-js/blob/main/docs/options.md) for color theme, question shuffling, localization.
-
 
 
 ## Credits

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -36,13 +36,14 @@ extensions = [
 
 # global options passed to the quizdown library
 quizdown_config = {
-    'quizdown_js': 'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js', # quizdown javascript
+    'quizdown_js': '/home/steiner/projects/github/quizdown-js/public/build/quizdown.js', # quizdown javascript
+    # 'quizdown_highlight_js' : '' # Set js for highlight code snippets
     'start_on_load': True,			# detect and convert all divs with class quizdown
     'shuffle_answers': True,		# shuffle answers for each question
-    'shuffle_questions': False,     # shuffle questsions for each quiz
+    'shuffle_questions': True,     # shuffle questsions for each quiz
     'primary_color': '#FF851B',     # primary CSS color
     'secondary_color': '#DDDDDD',   # secondary CSS color
-    'title_color': 'black'          # text color of the title
+    'title_color': 'green'          # text color of the title
 }
 
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -37,13 +37,14 @@ extensions = [
 # global options passed to the quizdown library
 quizdown_config = {
     'quizdown_js': '/home/steiner/projects/github/quizdown-js/public/build/quizdown.js', # quizdown javascript
-    # 'quizdown_highlight_js' : '' # Set js for highlight code snippets
     'start_on_load': True,			# detect and convert all divs with class quizdown
     'shuffle_answers': True,		# shuffle answers for each question
     'shuffle_questions': True,     # shuffle questsions for each quiz
     'primary_color': '#FF851B',     # primary CSS color
     'secondary_color': '#DDDDDD',   # secondary CSS color
-    'title_color': 'green'          # text color of the title
+    'title_color': 'green',          # text color of the title
+    'highlight_code': True,        # Enable or disable code highlighting
+    # 'quizdown_highlight_js' : '' # Set js for highlight code snippets
 }
 
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -10,10 +10,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
+import os
+import sys
+sys.path.append(os.path.abspath("../sphinxcontrib/"))
 
 # -- Project information -----------------------------------------------------
 
@@ -31,7 +30,7 @@ release = '0.3.0'
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'sphinxcontrib.quizdown'
+    'quizdown'
 ]
 
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -44,9 +44,9 @@ quizdown_config = {
     'secondary_color': '#DDDDDD',   # secondary CSS color
     'title_color': 'green',         # text color of the title
     'highlight_code': True,         # Enable or disable code highlighting
-    # 'quizdown_highlight_js' : ''  # Set js for highlight code snippets
-    'katex_math' : True,
-    # 'katex_math_js': ''
+    # 'quizdown_highlight_js' : ''  # Code highlight js
+    'katex_math' : True,            # Enable or disable katex math parser
+    # 'katex_math_js': ''           # Katex js
 }
 
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -44,7 +44,7 @@ quizdown_config = {
     'secondary_color': '#DDDDDD',   # secondary CSS color
     'title_color': 'green',          # text color of the title
     'highlight_code': True,        # Enable or disable code highlighting
-    # 'quizdown_highlight_js' : '' # Set js for highlight code snippets
+    'quizdown_highlight_js' : '/home/steiner/projects/github/quizdown-js/public/build/extensions/quizdownHighlight.js' # Set js for highlight code snippets
 }
 
 

--- a/demo/conf.py
+++ b/demo/conf.py
@@ -36,17 +36,18 @@ extensions = [
 
 # global options passed to the quizdown library
 quizdown_config = {
-    'quizdown_js': '/home/steiner/projects/github/quizdown-js/public/build/quizdown.js', # quizdown javascript
+    # 'quizdown_js': '',            # quizdown javascript
     'start_on_load': True,			# detect and convert all divs with class quizdown
     'shuffle_answers': True,		# shuffle answers for each question
-    'shuffle_questions': True,     # shuffle questsions for each quiz
+    'shuffle_questions': True,      # shuffle questsions for each quiz
     'primary_color': '#FF851B',     # primary CSS color
     'secondary_color': '#DDDDDD',   # secondary CSS color
-    'title_color': 'green',          # text color of the title
-    'highlight_code': True,        # Enable or disable code highlighting
-    'quizdown_highlight_js' : '/home/steiner/projects/github/quizdown-js/public/build/extensions/quizdownHighlight.js' # Set js for highlight code snippets
+    'title_color': 'green',         # text color of the title
+    'highlight_code': True,         # Enable or disable code highlighting
+    # 'quizdown_highlight_js' : ''  # Set js for highlight code snippets
+    'katex_math' : True,
+    # 'katex_math_js': ''
 }
-
 
 
 # Add any paths that contain templates here, relative to this directory.

--- a/demo/quiz.md
+++ b/demo/quiz.md
@@ -10,11 +10,6 @@ locale: en
 <a href="url">link text</a>
 ```
 
-$$
-x=\sqrt{\frac{9}{16}}
-$$
-
-
 Select all correct answers:
 
 - [x] A tag represents an html element.

--- a/demo/quiz.md
+++ b/demo/quiz.md
@@ -9,10 +9,11 @@ locale: en
 ```html
 <a href="url">link text</a>
 ```
-```c
-int a = 10;
-printf("a = %d", a);
-```
+
+$$
+x=\sqrt{\frac{9}{16}}
+$$
+
 
 Select all correct answers:
 

--- a/demo/quiz.md
+++ b/demo/quiz.md
@@ -9,6 +9,10 @@ locale: en
 ```html
 <a href="url">link text</a>
 ```
+```c
+int a = 10;
+printf("a = %d", a);
+```
 
 Select all correct answers:
 

--- a/demo/quiz.md
+++ b/demo/quiz.md
@@ -4,6 +4,19 @@ shuffle_questions: false
 locale: en
 ---
 
+### What is the difference between a tag and an attribute?
+
+```html
+<a href="url">link text</a>
+```
+
+Select all correct answers:
+
+- [x] A tag represents an html element.
+- [x] An attribute defines a property of an html element.
+- [ ] An attribute is everything between the opening and closing tag.
+- [ ] `"url"` is an attribute in the example above.
+
 #### Who is the person in the picture?
 
 ![](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9d/Sir_Tim_Berners-Lee.jpg/330px-Sir_Tim_Berners-Lee.jpg)
@@ -43,22 +56,6 @@ locale: en
 - [ ] for defining a paragraph
 - [ ] for defining code snippet
 - [ ] for defining an image
-
-
-
-### What is the difference between a tag and an attribute?
-
-```html
-<a href="url">link text</a>
-```
-
-Select all correct answers:
-
-- [x] A tag represents an html element.
-- [x] An attribute defines a property of an html element.
-- [ ] An attribute is everything between the opening and closing tag.
-- [ ] `"url"` is an attribute in the example above.
-
 
 #### How many valid HTML element tags are currently defined?
 

--- a/sphinxcontrib/quizdown/__init__.py
+++ b/sphinxcontrib/quizdown/__init__.py
@@ -53,7 +53,7 @@ class Quizdown(SphinxDirective):
         return [quiznode]
 
 
-def add_quizdown_lib(app, pagename, templatename, context, doctree):
+def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
     quizdown_js = app.config.quizdown_config.setdefault(
         'quizdown_js', 
         'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js'
@@ -64,7 +64,7 @@ def add_quizdown_lib(app, pagename, templatename, context, doctree):
     app.add_js_file(None, body=f"quizdown.init({config_json});")
 
 
-def setup(app):
+def setup(app: Sphinx):
     app.add_directive('quizdown', cls=Quizdown)    
     app.add_config_value('quizdown_config', {}, 'html')
     app.connect('html-page-context', add_quizdown_lib)

--- a/sphinxcontrib/quizdown/__init__.py
+++ b/sphinxcontrib/quizdown/__init__.py
@@ -58,8 +58,12 @@ def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
         'quizdown_js', 
         'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js'
     )
-    app.add_js_file("https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js")
+    quizdown_highlight_js = app.config.quizdown_config.setdefault(
+        'quizdown_highlight_js', 
+        'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js'
+    )
     app.add_js_file(quizdown_js)
+    app.add_js_file(quizdown_highlight_js)
     config_json = json.dumps(app.config.quizdown_config)
     app.add_js_file(None, body=f"quizdown.init({config_json});")
     app.add_js_file(None, body=f"quizdown.register(quizdownHighlight);")

--- a/sphinxcontrib/quizdown/__init__.py
+++ b/sphinxcontrib/quizdown/__init__.py
@@ -60,7 +60,6 @@ def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
     )
     app.add_js_file(quizdown_js)
 
-
     highlight_code = app.config.quizdown_config.setdefault(
         'highlight_code', False)
 
@@ -70,10 +69,20 @@ def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
             'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js'
         )
         app.add_js_file(quizdown_highlight_js)
-    
+        app.add_js_file(None, body=f"quizdown.register(quizdownHighlight);")
+
+    katex_math = app.config.quizdown_config.setdefault('katex_math', False)
+
+    if katex_math:
+        katex_math_js = app.config.quizdown_config.setdefault(
+            'katex_math_js',
+            'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@0.6.0/public/build/extensions/quizdownKatex.js'
+        )
+        app.add_js_file(katex_math_js)
+        app.add_js_file(None, body=f"quizdown.register(quizdownKatex);")
+
     config_json = json.dumps(app.config.quizdown_config)
     app.add_js_file(None, body=f"quizdown.init({config_json});")
-    app.add_js_file(None, body=f"quizdown.register(quizdownHighlight);")
 
 
 def setup(app: Sphinx):

--- a/sphinxcontrib/quizdown/__init__.py
+++ b/sphinxcontrib/quizdown/__init__.py
@@ -58,10 +58,11 @@ def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
         'quizdown_js', 
         'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js'
     )
-
+    app.add_js_file("https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js")
     app.add_js_file(quizdown_js)
     config_json = json.dumps(app.config.quizdown_config)
     app.add_js_file(None, body=f"quizdown.init({config_json});")
+    app.add_js_file(None, body=f"quizdown.register(quizdownHighlight);")
 
 
 def setup(app: Sphinx):

--- a/sphinxcontrib/quizdown/__init__.py
+++ b/sphinxcontrib/quizdown/__init__.py
@@ -55,22 +55,29 @@ class Quizdown(SphinxDirective):
 
 def add_quizdown_lib(app: Sphinx, pagename, templatename, context, doctree):
     quizdown_js = app.config.quizdown_config.setdefault(
-        'quizdown_js', 
+        'quizdown_js',
         'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/quizdown.js'
     )
-    quizdown_highlight_js = app.config.quizdown_config.setdefault(
-        'quizdown_highlight_js', 
-        'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js'
-    )
     app.add_js_file(quizdown_js)
-    app.add_js_file(quizdown_highlight_js)
+
+
+    highlight_code = app.config.quizdown_config.setdefault(
+        'highlight_code', False)
+
+    if highlight_code:
+        quizdown_highlight_js = app.config.quizdown_config.setdefault(
+            'quizdown_highlight_js',
+            'https://cdn.jsdelivr.net/gh/bonartm/quizdown-js@latest/public/build/extensions/quizdownHighlight.js'
+        )
+        app.add_js_file(quizdown_highlight_js)
+    
     config_json = json.dumps(app.config.quizdown_config)
     app.add_js_file(None, body=f"quizdown.init({config_json});")
     app.add_js_file(None, body=f"quizdown.register(quizdownHighlight);")
 
 
 def setup(app: Sphinx):
-    app.add_directive('quizdown', cls=Quizdown)    
+    app.add_directive('quizdown', cls=Quizdown)
     app.add_config_value('quizdown_config', {}, 'html')
     app.connect('html-page-context', add_quizdown_lib)
     return {


### PR DESCRIPTION
# Initial Situation
The sphinx extension does not enabling the code highlight script and the katex math parser.
To enable them, they must be manually enabled in the conf file of the users website.

# New Features
With these changes, the user can enabling and set the path to the js file in the conf file without adding own js code or adding the script file and the initialization by him.
The new configuration variable are:
- highlight_code: False => Boolean to enable or disable the highlight code 
- highlight_code_js: '' => Path string to manual link to the js file  
- katex_math :  False =>Boolean to enable or disable katex math parser
- katex_math_js: '' => Path string to manual link to the js file